### PR TITLE
Secure path from spaces in argument

### DIFF
--- a/dynamic-stack/mdps-generate.sh
+++ b/dynamic-stack/mdps-generate.sh
@@ -6,9 +6,9 @@ len=${#args[@]}
 if [ $len = 3 ] #3 arguments are required
 then
    echo "Running the Modern Data Platform Stack Generator ...."
-   docker run --rm -v ${args[0]}:/tmp/custom-values.yml -v ${args[1]}:/opt/analytics-generator/stacks  --user $(id -u):$(id -g) trivadis/modern-data-platform-stack-generator:${args[2]}
+   docker run --rm -v "${args[0]}":/tmp/custom-values.yml -v "${args[1]}":/opt/analytics-generator/stacks  --user $(id -u):$(id -g) trivadis/modern-data-platform-stack-generator:"${args[2]}"
    # Remove all empty lines at the end of the file
-   sed -i -e :a -e '/^\n*$/{$d;N;ba' -e '}' ${args[1]}/docker-compose.yml
+   sed -i -e :a -e '/^\n*$/{$d;N;ba' -e '}' "${args[1]}/docker-compose.yml"
    echo "Modern Data Platform Stack generated successfully to ${args[1]}"
 else
   echo "mdps-generate version 1.0.0"


### PR DESCRIPTION
When the path has spaces in it, the error occurs
invalid reference format: repository name must be lowercase

Similar problem: https://stackoverflow.com/questions/48522615/docker-error-invalid-reference-format-repository-name-must-be-lowercase